### PR TITLE
"附錄三" 編校完成

### DIFF
--- a/appendix_resources/README.md
+++ b/appendix_resources/README.md
@@ -1,7 +1,7 @@
 # 資源鏈接
-* Docker 主站點: https://www.docker.com
+* Docker 主站台: https://www.docker.com
 * Docker 註冊中心 API: http://docs.docker.com/reference/api/registry_api/
 * Docker Hub API: http://docs.docker.com/reference/api/docker-io_api/
 * Docker 遠端應用 API: http://docs.docker.com/reference/api/docker_remote_api/
-* Dockerfile 參考：https://docs.docker.com/reference/builder/
-* Dockerfile 最佳實踐：https://docs.docker.com/articles/dockerfile_best-practices/
+* Dockerfile 參考: https://docs.docker.com/reference/builder/
+* Dockerfile 最佳實踐: https://docs.docker.com/articles/dockerfile_best-practices/


### PR DESCRIPTION
# 修正用語
- 站點 -> 站台
# 潤飾
- 中英夾雜時，英數以空白間隔
- 更新 docker 主站台 URL (http://www.docker.io 已重導至 http://www.docker.com)
- 統一採用半形冒號
